### PR TITLE
Do not store AUTOLOAD PV

### DIFF
--- a/lib/B/C/OverLoad/B/PV.pm
+++ b/lib/B/C/OverLoad/B/PV.pm
@@ -129,6 +129,19 @@ sub save_svu {
 
     $fullname = '' if !defined $fullname;
 
+    if ( $fullname =~ m{^(.+)::AUTOLOAD$} ) {
+        my $pkg = $1;
+        if ( $pkg->can( 'AUTOLOAD' ) ) {
+            # clear AUTOLOAD PV when used at compile time
+            #print STDERR "## $fullname has AUTOLOAD sub\n";
+            $savesym = 'NULL';
+            $cur = 0;
+            $len = 0;
+            $pv  = '';
+            $flags = 0;
+        }
+    }
+
     debug( pv => "Saving pv %s %s cur=%d, len=%d, %s", $savesym, $pv, $cur, $len, $shared_hek ? "shared, $fullname" : $fullname );
 
     $savesym = ".svu_pv=(char*) $savesym";

--- a/t/testsuite/C-COMPILED/extra/autoload.t
+++ b/t/testsuite/C-COMPILED/extra/autoload.t
@@ -1,0 +1,1 @@
+../template.pl

--- a/t/testsuite/t/extra/autoload.t
+++ b/t/testsuite/t/extra/autoload.t
@@ -1,0 +1,17 @@
+#!perl
+
+sub do_test {
+  print "ok 1 - test at ".${^GLOBAL_PHASE}."\n";
+}
+
+sub AUTOLOAD {
+    substr( $AUTOLOAD, 0, 1 + rindex( $AUTOLOAD, ':' ) ) = q<>;
+    return do_test();
+}
+
+print "1..1\n";
+
+# alter AUTOLOAD at compile time
+BEGIN { test() }
+# try to reuse it at run time
+test();


### PR DESCRIPTION
If $AUTOLOAD is used at compile time
whereas there is an existing AUTOLOAD CV
available, reset the $PV as if it was never used.