### PR TITLE
Fix SEGV when clearing UNOP_AUX with PL_*

### DIFF
--- a/lib/B/C/OverLoad/B/UNOP_AUX.pm
+++ b/lib/B/C/OverLoad/B/UNOP_AUX.pm
@@ -136,6 +136,7 @@ sub do_save {
                 if ( $itemsym =~ qr{^PL_} ) {
                     $field = "{.sv=Nullsv}";        #  \t/* $itemsym */
                     init()->add("$symat.sv = (SV*)$itemsym;");
+                    init()->add("SvREFCNT_inc_NN((SV*)$itemsym);");
                 }
                 else {
                     ## gv or other late inits

--- a/t/testsuite/C-COMPILED/extra/argv-3.t
+++ b/t/testsuite/C-COMPILED/extra/argv-3.t
@@ -1,0 +1,1 @@
+../template.pl

--- a/t/testsuite/C-COMPILED/extra/env-2.t
+++ b/t/testsuite/C-COMPILED/extra/env-2.t
@@ -1,0 +1,1 @@
+../template.pl

--- a/t/testsuite/C-COMPILED/extra/env-3.t
+++ b/t/testsuite/C-COMPILED/extra/env-3.t
@@ -1,0 +1,1 @@
+../template.pl

--- a/t/testsuite/C-COMPILED/extra/env-4.t
+++ b/t/testsuite/C-COMPILED/extra/env-4.t
@@ -1,0 +1,1 @@
+../template.pl

--- a/t/testsuite/C-COMPILED/extra/env-binary-2.t
+++ b/t/testsuite/C-COMPILED/extra/env-binary-2.t
@@ -1,0 +1,1 @@
+../template.pl

--- a/t/testsuite/t/extra/argv-3.t
+++ b/t/testsuite/t/extra/argv-3.t
@@ -1,0 +1,11 @@
+#!perl
+
+sub mysub {
+    $ARGV{DEBUG} | $ARGV{DEBUG} | $ARGV{DEBUG};
+}
+
+mysub();
+undef *mysub;
+
+print "1..1\n";
+print "ok 1\n" if $::{ARGV};

--- a/t/testsuite/t/extra/env-2.t
+++ b/t/testsuite/t/extra/env-2.t
@@ -1,0 +1,12 @@
+#!perl
+
+sub mysub {
+    undef *mysub;
+    1 if $ENV{F};
+    1 if $ENV{F};
+}
+
+mysub();
+
+print "1..1\n";
+print "ok 1\n" if $::{ENV};

--- a/t/testsuite/t/extra/env-3.t
+++ b/t/testsuite/t/extra/env-3.t
@@ -1,0 +1,13 @@
+#!perl
+
+sub mysub {
+    undef *mysub;
+    1 if $ENV{F};
+    1 if $ENV{F};
+    1 if $ENV{F};
+}
+
+mysub();
+
+print "1..1\n";
+print "ok 1\n" if $::{ENV};

--- a/t/testsuite/t/extra/env-4.t
+++ b/t/testsuite/t/extra/env-4.t
@@ -1,0 +1,14 @@
+#!perl
+
+sub mysub {
+    undef *mysub;
+    1 if $ENV{F};
+    1 if $ENV{F};
+    1 if $ENV{F};
+    1 if $ENV{F};
+}
+
+mysub();
+
+print "1..1\n";
+print "ok 1\n" if $::{ENV};

--- a/t/testsuite/t/extra/env-binary-2.t
+++ b/t/testsuite/t/extra/env-binary-2.t
@@ -1,0 +1,12 @@
+#!perl
+
+sub mysub {
+    undef *mysub;
+
+    return $ENV{A} | $ENV{B};
+}
+
+mysub();
+
+print "1..1\n";
+print "ok 1\n" if $::{ENV};


### PR DESCRIPTION
    Case BC-3093:

    Avoid to free CORE GVs when clearing UNOP_AUX.

    In order to use %ENV and %ARGV a compiled program
    will directly use PL_envgv or PL_argvgv, but do not hold
    a refcnt on it. So when destroying the UNOP_AUX this could
    result in clearing the GV itself..

    We should increase the refcnt when using these variables.

    The issue was limited to PL_envgv and PL_argvgv
    listed as special CORE_SYMS in GV.pm

    Add unit tests to show the SEGV issue when
    clearing UNOP_AUX using %ENV or %ARGV.