### PR TITLE
basic B::C: hook system

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -11,6 +11,9 @@ lib/B/C/Decimal.pm
 lib/B/C/File.pm
 lib/B/C/Helpers.pm
 lib/B/C/Helpers/Symtable.pm
+lib/B/C/Hooks.pm
+lib/B/C/Hooks/Base.pm
+lib/B/C/Hooks/Loader.pm
 lib/B/C/InitSection.pm
 lib/B/C/InitSection/Vtables.pm
 lib/B/C/InitSection/XOPs.pm

--- a/lib/B/C/Debug.pm
+++ b/lib/B/C/Debug.pm
@@ -28,6 +28,8 @@ my %debug_map = (
     'W'     => 'walk',
     'bench' => 'benchmark',
     'stack' => 'stack',
+    'h'     => 'hooks',
+    'hook'  => 'hooks',
 );
 
 my %reverse_map = reverse %debug_map;

--- a/lib/B/C/File.pm
+++ b/lib/B/C/File.pm
@@ -31,6 +31,7 @@ use B::C::Section           ();
 use B::C::Section::Meta     ();
 use B::C::InitSection       ();
 use B::C::Section::Assign   ();
+use B::C::Hooks             ();
 
 use B qw(cstring comppadlist);
 
@@ -189,9 +190,15 @@ sub replace_xs_bootstrap_to_init {
     return;
 }
 
+sub hooks ($self) {
+    return $self->{hooks} //= B::C::Hooks->new();
+}
+
 sub write ( $c_file_stash, $template_name_short = undef ) {
     die unless $c_file_stash;
     $template_name_short ||= 'base.c.tt2';
+
+    $self->hooks->pre_write();    # can alter sections before setting c_file_stash
 
     # TODO: refactor move section group logic outside of the 'write' which is the main purpose of File
     # Controls the rendering order of the sections.
@@ -279,6 +286,8 @@ sub write ( $c_file_stash, $template_name_short = undef ) {
 
     open( my $fh, '>:utf8', $self->{'c_file_name'} ) or die;
 
+    $self->hooks->pre_process( stash => $c_file_stash );
+
     # process input template, substituting variables
     $template->process( $template_name_short, $c_file_stash, $fh ) or die $template->error();
 
@@ -295,6 +304,9 @@ sub write ( $c_file_stash, $template_name_short = undef ) {
         $context->DESTROY if ref $context;
         $template->DESTROY;
     }
+    close $fh;
+
+    $self->hooks->post_process( c_file_name => $self->{'c_file_name'} );
 
     return;
 }

--- a/lib/B/C/Hooks.pm
+++ b/lib/B/C/Hooks.pm
@@ -1,0 +1,129 @@
+package B::C::Hooks;
+
+use B::C::Std;
+
+use B::C::Debug ();
+
+sub new ( $class, %opts ) {
+
+    my $self = bless {}, $class;
+
+    $self->_load_hooks();
+
+    return $self;
+
+}
+
+sub _dd ($str) {
+    return B::C::Debug::debug( 'hooks' => $str );
+}
+
+sub _load_hooks ($self) {
+
+    # this is where you want to load your hooks
+    return unless eval { require B::C::Hooks::Loader; 1 };
+
+    foreach my $k ( sort keys %INC ) {
+        next unless $k =~ qr{^B/C/Hooks/([^/]+)\.pm$};
+        my $hook = $1;
+        next if $hook eq 'Loader';    # loader entry point
+        next if $hook eq 'Base';      # this is the base class
+
+        my $pkg = "B::C::Hooks::$hook";
+
+        _dd("detecting B::C hook '$hook'");
+
+        $self->{hooks} //= [];
+        push $self->{hooks}->@*, $pkg->new();
+    }
+
+    return;
+}
+
+sub _hooks ($self) {
+    return ( $self->{hooks} // [] );
+}
+
+=pod
+
+=head2 pre_write( $self, %opts )
+
+Call the 'pre_write' hook on all loaded hooks.
+This is happening before we start generating the stash.
+
+This is a good time to alter section contents before we generate the stash.
+
+=cut
+
+sub pre_write ( $self, %opts ) {
+    return $self->_visit( 'pre_write', %opts );
+}
+
+=pod
+
+=head2 pre_process( $self, %opts )
+
+Call the 'pre_process' hook on all loaded hooks.
+This is happening before we render the template.
+
+Provided option:
+ - stash: access to the stash
+
+=cut
+
+sub pre_process ( $self, %opts ) {
+
+    # init the hooks entry in our main stasg
+    my $global_stash = $opts{stash}->{hooks} = {};
+
+    $opts{post_visit} = sub ($hook) {
+
+        return unless my $hook_stash = $hook->get_stash;
+
+        foreach my $k ( keys %$hook_stash ) {
+            $global_stash->{$k} //= '';
+            $global_stash->{$k} .= sprintf( "\n/* %s - %s */\n", ref $hook, $k );
+            $global_stash->{$k} .= $hook_stash->{$k};
+        }
+
+        return;
+    };
+
+    return $self->_visit( 'pre_process', %opts );
+}
+
+=pod
+
+=head2 post_process( $self, %opts )
+
+Call the 'post_process' hook on all loaded hooks.
+This is happening after processing the template.
+
+Provided option:
+ - c_file_name: name of the temporary file to generate the c code.
+
+=cut
+
+sub post_process ( $self, %opts ) {
+    return $self->_visit( 'post_process', %opts );
+}
+
+sub _visit ( $self, $method, %opts ) {
+
+    foreach my $hook ( $self->_hooks->@* ) {
+        next unless my $sub = $hook->can($method);
+
+        my $post_visit = delete $opts{post_visit};
+
+        $hook->debug("calling hook '$method'");
+        $sub->( $hook, %opts );
+
+        if ($post_visit) {
+            $post_visit->($hook);
+        }
+    }
+
+    return;
+}
+
+1;

--- a/lib/B/C/Hooks/Base.pm
+++ b/lib/B/C/Hooks/Base.pm
@@ -1,0 +1,27 @@
+package B::C::Hooks::Base;
+
+use B::C::Std;
+use B::C::Debug ();
+
+sub new ( $class, %opts ) {
+
+    return bless {}, $class;
+}
+
+sub debug ( $self, $str ) {
+    return B::C::Debug::debug( 'hooks' => ref($self) . ' ' . $str );
+}
+
+sub stash ( $self, $k, $v ) {
+
+    $self->{stash} //= {};
+    $self->{stash}->{$k} = $v;
+
+    return;
+}
+
+sub get_stash ($self) {
+    return $self->{stash};
+}
+
+1;

--- a/lib/B/C/Hooks/Loader.pm
+++ b/lib/B/C/Hooks/Loader.pm
@@ -1,0 +1,18 @@
+package B::C::Hooks::Loader;
+
+=pod
+
+This package a place hodler.
+
+This is used to declare your custom hooks.
+B::C loads 'B::C::Hooks::Loader' and then
+register all Hooks loaded.
+
+Overwrite it and load your custom hooks.
+
+	use B::C::Hooks::MyFirstHook  ();
+	use B::C::Hooks::MySecondHook ();
+
+=cut
+
+1;

--- a/lib/B/C/Templates/base.c.tt2
+++ b/lib/B/C/Templates/base.c.tt2
@@ -1062,6 +1062,8 @@ static void bc_init_signals() {
 }
 [% END -%]
 
+[% hooks.before_main %]
+
 /************************************************************************************************************
 *
 *       output_main()
@@ -1086,6 +1088,8 @@ main(int argc, char **argv, char **env)
 
     /* Assure the interpreter struct is zeroed out. */
     Zero(&BC_unthreaded_interpreter, 1, PerlInterpreter);
+
+    [% hooks.main_after_zero %]
 
 #if USE_BC_NEWXZ
     /* use one single big malloc for all our stuff */


### PR DESCRIPTION
This commit implements a basic Hook system
to plug some additional on-demand logic to the
Perl compiler.

There are three kinds of hooks:
1. pre_write: you can alter sections before setting the stash built for Template::Toolkit

2. pre_process: this is happening jyst before rendering the C template. That hook have access to the stash. It can alter the stash or even setup some custom entries like 'hooks.before_main' or 'hooks.main_after_zero'.

3. post_process: this last hook provide you full control of the generated file via 'c_file_name'. This is happening after processing the template.

All custom hooks should exist in the B::C::Hooks namespace and use B::C:Hooks::Base as a parent class.

To declare hooks you can preload them providing your own 'B::C::Hooks::Loader'.