### PR TITLE
Init empty arrays using INITAv

### DIFF
--- a/lib/B/C/OverLoad/B/AV.pm
+++ b/lib/B/C/OverLoad/B/AV.pm
@@ -194,7 +194,7 @@ sub do_save {
     }
     else {
         my $max = $av->MAX;
-        init()->sadd( "av_extend(%s, %d);", $sym, $max ) if $max > -1;
+        $av->add_to_init( $sym, '', $fill, $fullname ) if $max > -1;
     }
 
     $av->update_sv( $ix, $fullname, { fill => $fill } );    # could be using PADLIST, PADNAMELIST, or AV method for this.


### PR DESCRIPTION
We should not try to save Exporter::EXPORT_FAIL

Refs: CPANEL-42007
(cherry picked from commit 5fe9e321fd99644a0456667d769ed5faea743639)
Signed-off-by: Nicolas Rochelemagne <rochelemagne@cpanel.net>