### PR TITLE
fix: update perl paths from 540 to 542 in setup scripts

### DIFF
--- a/configure.cpanel
+++ b/configure.cpanel
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export PATH=/usr/local/cpanel/3rdparty/perl/540/bin/:$PATH
+export PATH=/usr/local/cpanel/3rdparty/perl/542/bin/:$PATH
 
 #set -e
 LOG=/tmp/log.bc.configure

--- a/setup.cpanel
+++ b/setup.cpanel
@@ -5,7 +5,7 @@
 
 ARG="$1" # --debug
 PERL=$(which perl)
-BINPERL="/usr/local/cpanel/3rdparty/perl/540/bin"
+BINPERL="/usr/local/cpanel/3rdparty/perl/542/bin"
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     echo "You need to source that file: 'source $0'"


### PR DESCRIPTION
    configure.cpanel and setup.cpanel still referenced perl 540 paths.
    Updated to 542 to match the bc542 branch target.
