### PR TITLE
fix: save cop_features bits in compiled COP structs

### DIFF
--- a/C.xs
+++ b/C.xs
@@ -1021,6 +1021,14 @@ cop_refcounted_warnings (cop)
         }
 
 
+U32
+cop_features_bits (cop)
+      B::COP cop;
+    CODE:
+        RETVAL = cop->cop_features.bits[0];
+    OUTPUT:
+        RETVAL
+
 #/* ************************************************************ */
 MODULE = B__C          PACKAGE = B::C
 #/* ************************************************************ */

--- a/lib/B/C/OverLoad/B/COP.pm
+++ b/lib/B/C/OverLoad/B/COP.pm
@@ -62,8 +62,7 @@ sub do_save ( $op, @ ) {
         '%s'       => get_integer_value( $op->cop_seq ),    # U32     cop_seq;    /* parse sequence number */
         '%s'       => $op->save_warnings,                   # char *    cop_warnings;   /* lexical warnings bitmask */
         '%s'       => $op->save_hints,                      # COPHH * cop_hints_hash; /* compile time state of %^H. */
-        # TODO cop_features is not used in the compiler, but it is used in the interpreter.
-        '%s'       => '0',                                  # struct cop_feature_t       cop_features; 
+        '%s'       => $op->save_cop_features,               # struct cop_feature_t       cop_features;
     );
 
     return $sym;
@@ -148,6 +147,11 @@ sub save_warnings ($op) {
 
     # set cache
     return $lexwarnsym_cache{$pv} = sprintf( "(char*) &(lexwarn_list[%d].pv)", $ix );
+}
+
+sub save_cop_features ($op) {
+    my $bits = $op->features_bits;
+    return sprintf( '{.bits={0x%x}}', $bits );
 }
 
 1;

--- a/t/testsuite/C-COMPILED/bctestc/76.cop-features-say-state.t
+++ b/t/testsuite/C-COMPILED/bctestc/76.cop-features-say-state.t
@@ -1,0 +1,1 @@
+../bctest.pl

--- a/t/testsuite/C-COMPILED/bctestc/76.cop-features-say.t
+++ b/t/testsuite/C-COMPILED/bctestc/76.cop-features-say.t
@@ -1,0 +1,1 @@
+../bctest.pl

--- a/t/testsuite/t/bctestc/76.cop-features-say-state.t
+++ b/t/testsuite/t/bctestc/76.cop-features-say-state.t
@@ -1,0 +1,8 @@
+#!./perl
+
+# cop_features: verify multiple custom feature flags survive compilation.
+
+use feature "say", "state";
+
+state $msg = "ok";
+say $msg;

--- a/t/testsuite/t/bctestc/76.cop-features-say.t
+++ b/t/testsuite/t/bctestc/76.cop-features-say.t
@@ -1,0 +1,9 @@
+#!./perl
+
+# cop_features: verify that 'use feature "say"' is preserved in compiled output.
+# Without proper cop_features serialization, 'say' silently loses its feature
+# flag when the bundle is FEATURE_BUNDLE_CUSTOM.
+
+use feature "say";
+
+say "ok";


### PR DESCRIPTION
The cop_features field was hardcoded to 0 in compiled output. This caused feature flags to be lost when the feature bundle is FEATURE_BUNDLE_CUSTOM (e.g. explicit 'use feature "say"'), since the interpreter checks cop_features.bits[] via FEATURE_IS_ENABLED_MASK only when HINT_LOCALIZE_HH is set in cop_hints.

Added cop_features_bits() XS accessor to B::COP in C.xs and save_cop_features() method in COP.pm to properly serialize the cop_features struct into the generated C initializer.